### PR TITLE
Update Thread_Library.scad

### DIFF
--- a/Threaded Library/Thread_Library.scad
+++ b/Threaded Library/Thread_Library.scad
@@ -5,6 +5,8 @@ function unitVector(vector) = vector / norm ( vector );
 
 function barycenter(vector1, vector2, ratio) = (vector1*ratio + vector2*(1-ratio) );
 
+function moveUp(vector, o = 0.1) = [vector[0], vector[1], vector[2] + o];
+
 module slice( 
 	AShaftBottom,
 	AShaftTop,
@@ -27,15 +29,15 @@ module slice(
 { 
 	polyPoints=[
 		AShaftBottom,
-		AShaftTop,
-		ATop,
+		moveUp(AShaftTop),
+		moveUp(ATop),
 		barycenter(ATop,ABottom,AThreadPosition+AThreadRatio/2) + unitVector(ATop-ABottom)*AThreadDepth/2*tan(AThreadAngle),
 		barycenter(ATop,ABottom,AThreadPosition+AThreadRatio/2) - unitVector(ATop-ABottom)*AThreadDepth/2*tan(AThreadAngle) + unitVector(ATop-AShaftTop)*AThreadDepth,
 		barycenter(ATop,ABottom,AThreadPosition),
 		barycenter(ATop,ABottom,AThreadPosition-AThreadRatio/2) + unitVector(ATop-ABottom)*AThreadDepth/2*tan(AThreadAngle) + unitVector(ATop-AShaftTop)*AThreadDepth,
 		barycenter(ATop,ABottom,AThreadPosition-AThreadRatio/2) - unitVector(ATop-ABottom)*AThreadDepth/2*tan(AThreadAngle),
 		ABottom,
-		BTop,
+		moveUp(BTop),
 		barycenter(BTop,BBottom,BThreadPosition+BThreadRatio/2) + unitVector(BTop-BBottom)*BThreadDepth/2*tan(BThreadAngle),
 		barycenter(BTop,BBottom,BThreadPosition+BThreadRatio/2) - unitVector(BTop-BBottom)*BThreadDepth/2*tan(BThreadAngle) + unitVector(BTop-BShaftTop)*BThreadDepth,
 		barycenter(BTop,BBottom,BThreadPosition),


### PR DESCRIPTION
When substracting a negative trapezoid thread from a model, I always had to repair the resulting STL in order to print it without problems. The reason why it had to be repaired was because the model  contained non manifold edges in thread space.
The proposed fix makes the thread slices little higher to overlap with each other vertically, and as a result OpenSCAD happily generates the ideal STL.
I have only smoke tested the fix on a couple of projects, and it seems to be working there.
